### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#Android-ScreenShot
+# Android-ScreenShot
 
-##Welcome
+## Welcome
 This is the project help you to achieve screenshot function on android.
 The thoery of this function is based on shell command "/system/bin/screencap -p "
 
-##Get Start
+## Get Start
 
-###1.Root android phone 
-###2.Download the AndroidScreenCap.jar fill , and add it to the project.
-###3.Use function : takeScreenshot(Context context, String fileFullPath) , if "fileFullPath" is null , the pic will be saved at /data/local/tmp
+### 1.Root android phone 
+### 2.Download the AndroidScreenCap.jar fill , and add it to the project.
+### 3.Use function : takeScreenshot(Context context, String fileFullPath) , if "fileFullPath" is null , the pic will be saved at /data/local/tmp
 
-##Contact
+## Contact
 Some sample code can be found on the [Garvin-Blog](http://blog.csdn.net/buptgshengod/article/details/39155979) page.  
 Email:garvinli@garvinli.com or jie.cao@legensity.com  
       


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
